### PR TITLE
fix: make deno_exif usable via HTTP/HTTPS import

### DIFF
--- a/lib/bufferstream.js
+++ b/lib/bufferstream.js
@@ -85,4 +85,4 @@ BufferStream.prototype = {
 	}
 };
 
-module.exports = BufferStream;
+export default BufferStream;

--- a/lib/date.js
+++ b/lib/date.js
@@ -77,8 +77,8 @@ function parseExifDate(dateTimeStr) {
 	}
 }
 
-module.exports = {
-	parseDateWithSpecFormat: parseDateWithSpecFormat,
-	parseDateWithTimezoneFormat: parseDateWithTimezoneFormat,
-	parseExifDate: parseExifDate
+export default {
+	parseDateWithSpecFormat,
+	parseDateWithTimezoneFormat,
+	parseExifDate,
 };

--- a/lib/exif-tags.js
+++ b/lib/exif-tags.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
 	exif : {
 		0x0001 : "InteropIndex",
 		0x0002 : "InteropVersion",

--- a/lib/exif.js
+++ b/lib/exif.js
@@ -115,7 +115,7 @@ function readHeader(stream) {
 	return tiffMarker;
 }
 
-module.exports = {
+export default {
 	IFD0: 1,
 	IFD1: 2,
 	GPSIFD: 3,

--- a/lib/jpeg.js
+++ b/lib/jpeg.js
@@ -1,6 +1,6 @@
 /*jslint browser: true, devel: true, bitwise: false, debug: true, eqeq: false, es5: true, evil: false, forin: false, newcap: false, nomen: true, plusplus: true, regexp: false, unparam: false, sloppy: true, stupid: false, sub: false, todo: true, vars: true, white: true */
 
-module.exports = {
+export default {
 	parseSections: function(stream, iterator) {
 		var len, markerType;
 		stream.setBigEndian(true);

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,8 +1,9 @@
 /*jslint browser: true, devel: true, bitwise: false, debug: true, eqeq: false, es5: true, evil: false, forin: false, newcap: false, nomen: true, plusplus: true, regexp: false, unparam: false, sloppy: true, stupid: false, sub: false, todo: true, vars: true, white: true */
 
-var jpeg = require('./jpeg'),
-	exif = require('./exif'),
-	simplify = require('./simplify');
+import jpeg from './jpeg.js';
+import exif from './exif.js';
+import tagNames from './exif-tags.js';
+import simplify from './simplify.js';
 
 function ExifResult(startMarker, tags, imageSize, thumbnailOffset, thumbnailLength, thumbnailType, app1Offset) {
 	this.startMarker = startMarker;
@@ -103,11 +104,7 @@ Parser.prototype = {
 			thumbnailLength,
 			thumbnailType,
 			app1Offset,
-			tagNames,
 			getTagValue, setTagValue;
-		if(flags.resolveTagNames) {
-			tagNames = require('./exif-tags');
-		}
 		if(flags.resolveTagNames) {
 			tags = {};
 			getTagValue = function(t) {
@@ -199,6 +196,4 @@ Parser.prototype = {
 	}
 };
 
-
-
-module.exports = Parser;
+export default Parser;

--- a/lib/simplify.js
+++ b/lib/simplify.js
@@ -1,5 +1,5 @@
-var exif = require('./exif');
-var date = require('./date');
+import exif from './exif.js';
+import date from './date.js';
 
 var degreeTags = [{
 	section: exif.GPSIFD,
@@ -38,7 +38,7 @@ var dateTags = [{
 	name : 'ModifyDate',
 }];
 
-module.exports = {
+export default {
 	castDegreeValues: function(getTagValue, setTagValue) {
 		degreeTags.forEach(function(t) {
 			var degreeVal = getTagValue(t);

--- a/mod.ts
+++ b/mod.ts
@@ -1,9 +1,6 @@
-import { createRequire } from "https://deno.land/std@0.88.0/node/module.ts";
 import { Buffer } from "https://deno.land/std@0.88.0/node/buffer.ts";
-
-const require = createRequire(Deno.mainModule);
-const Parser = require("./lib/parser.js");
-const NodeBufferStream = require("./lib/bufferstream");
+import Parser from './lib/parser.js';
+import NodeBufferStream from './lib/bufferstream.js';
 
 export interface IExifResult {
   startMarker: { openWithOffset: Function; offset: number };


### PR DESCRIPTION
Convert the included CommonJS libs to ESM format to get rid of `createRequire` which doesn't work when importing the lib via HTTP/HTTPS.

Fixes #1